### PR TITLE
feat: support predefined models for $ref resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,22 @@ OpenAPIModel = create_model(
 For more complex scenarios, you can use the `PydanticModelBuilder` directly:
 
 ```python
+from pydantic import BaseModel
 from json_schema_to_pydantic import PydanticModelBuilder
 
-builder = PydanticModelBuilder()
+class PetModel(BaseModel):
+    name: str
+    type: str
+
+builder = PydanticModelBuilder(
+    predefined_models={"#/definitions/Pet": PetModel}
+)
 model = builder.create_pydantic_model(schema, root_schema)
 ```
+
+You can also pass `predefined_models` to `create_model(...)` directly.
+When a `$ref` key matches an entry in `predefined_models`, that class is reused
+instead of generating a new class.
 
 ## Error Handling
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -196,6 +196,44 @@ Example with nested references in array items:
 }
 ```
 
+### Reusing Existing Pydantic Models for `$ref`
+
+If your application already has canonical Pydantic models, you can pre-seed
+reference resolution so matched refs reuse those classes:
+
+```python
+from pydantic import BaseModel
+from json_schema_to_pydantic import create_model
+
+class PetModel(BaseModel):
+    name: str
+    type: str
+
+schema = {
+    "type": "object",
+    "properties": {"current_pet": {"$ref": "#/definitions/Pet"}},
+    "definitions": {
+        "Pet": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "type": {"type": "string"}},
+        }
+    },
+}
+
+Model = create_model(
+    schema,
+    predefined_models={"#/definitions/Pet": PetModel},
+)
+instance = Model(current_pet={"name": "Fluffy", "type": "cat"})
+assert type(instance.current_pet) is PetModel
+```
+
+Notes:
+- `predefined_models` keys must be local JSON Pointer refs such as
+  `#/definitions/Pet` or `#/$defs/Pet`.
+- Values must be subclasses of `pydantic.BaseModel`.
+- Exact ref-key matches take precedence over generated models.
+
 ## Limitations
 
 - External references are not supported

--- a/src/json_schema_to_pydantic/__init__.py
+++ b/src/json_schema_to_pydantic/__init__.py
@@ -28,6 +28,7 @@ def create_model(
     allow_undefined_array_items: bool = False,
     allow_undefined_type: bool = False,
     populate_by_name: bool = False,
+    predefined_models: Optional[Dict[str, Type[BaseModel]]] = None,
 ) -> Type[T]:
     """
     Create a Pydantic model from a JSON Schema.
@@ -40,6 +41,9 @@ def create_model(
         allow_undefined_array_items: If True, allows arrays without items schema
         allow_undefined_type: If True, allows schemas without an explicit type
         populate_by_name: If True, allows population of model fields by name and alias
+        predefined_models: Optional mapping of local JSON Pointer refs
+            (e.g. "#/definitions/MyModel") to existing Pydantic model classes.
+            Matching refs are reused instead of generating new model classes.
 
     Returns:
         A Pydantic model class
@@ -50,7 +54,10 @@ def create_model(
         CombinerError: If there's an error in schema combiners
         ReferenceError: If there's an error resolving references
     """
-    builder = PydanticModelBuilder(base_model_type=base_model_type)
+    builder = PydanticModelBuilder(
+        base_model_type=base_model_type,
+        predefined_models=predefined_models,
+    )
     return builder.create_pydantic_model(
         schema,
         root_schema,

--- a/src/json_schema_to_pydantic/model_builder.py
+++ b/src/json_schema_to_pydantic/model_builder.py
@@ -104,15 +104,19 @@ class PydanticModelBuilder(IModelBuilder[T]):
             name_sanitizer=self._sanitize_field_name,
         )
         self.base_model_type = base_model_type
-        validated_predefined_models = self._validate_predefined_models(predefined_models)
+        validated_predefined_models = self._validate_predefined_models(
+            predefined_models,
+            base_model_type=self.base_model_type,
+        )
         # Track models being built to handle recursive references
         self._model_cache: Dict[str, Type[BaseModel]] = dict(validated_predefined_models)
         self._building_models: Set[str] = set()
         self._models_to_rebuild: Set[Type[BaseModel]] = set()
 
-    @staticmethod
     def _validate_predefined_models(
+        self,
         predefined_models: Optional[Dict[str, Type[BaseModel]]],
+        base_model_type: Type[T],
     ) -> Dict[str, Type[BaseModel]]:
         """Validate and normalize predefined model mappings for $ref resolution."""
         if predefined_models is None:
@@ -130,10 +134,22 @@ class PydanticModelBuilder(IModelBuilder[T]):
                     f"'{ref}'. Keys must be local JSON Pointer refs like "
                     "'#/definitions/Model'"
                 )
+            path = ref[2:]
+            if not path or any(segment == "" for segment in path.split("/")):
+                raise ValueError(
+                    "Invalid predefined model ref "
+                    f"'{ref}'. Keys must be local JSON Pointer refs without empty path segments, "
+                    "for example '#/definitions/Model'"
+                )
 
             if not isinstance(model, type) or not issubclass(model, BaseModel):
                 raise ValueError(
                     f"Invalid predefined model for ref '{ref}'. Values must be subclasses of pydantic.BaseModel"
+                )
+            if not issubclass(model, base_model_type):
+                raise ValueError(
+                    f"Invalid predefined model for ref '{ref}'. Values must be subclasses of the configured "
+                    f"base_model_type ({base_model_type.__name__})"
                 )
             validated[ref] = model
         return validated

--- a/src/json_schema_to_pydantic/model_builder.py
+++ b/src/json_schema_to_pydantic/model_builder.py
@@ -85,7 +85,11 @@ class PydanticModelBuilder(IModelBuilder[T]):
         "uniqueItems",
     }
 
-    def __init__(self, base_model_type: Type[T] = BaseModel):
+    def __init__(
+        self,
+        base_model_type: Type[T] = BaseModel,
+        predefined_models: Optional[Dict[str, Type[BaseModel]]] = None,
+    ):
         # Instantiate resolvers and builders directly
         self.type_resolver = TypeResolver()
         self.constraint_builder = ConstraintBuilder()
@@ -100,10 +104,39 @@ class PydanticModelBuilder(IModelBuilder[T]):
             name_sanitizer=self._sanitize_field_name,
         )
         self.base_model_type = base_model_type
+        validated_predefined_models = self._validate_predefined_models(predefined_models)
         # Track models being built to handle recursive references
-        self._model_cache: Dict[str, Type[BaseModel]] = {}
+        self._model_cache: Dict[str, Type[BaseModel]] = dict(validated_predefined_models)
         self._building_models: Set[str] = set()
         self._models_to_rebuild: Set[Type[BaseModel]] = set()
+
+    @staticmethod
+    def _validate_predefined_models(
+        predefined_models: Optional[Dict[str, Type[BaseModel]]],
+    ) -> Dict[str, Type[BaseModel]]:
+        """Validate and normalize predefined model mappings for $ref resolution."""
+        if predefined_models is None:
+            return {}
+        if not isinstance(predefined_models, dict):
+            raise ValueError(
+                "predefined_models must be a dict mapping local $ref strings to BaseModel subclasses"
+            )
+
+        validated: Dict[str, Type[BaseModel]] = {}
+        for ref, model in predefined_models.items():
+            if not isinstance(ref, str) or not ref.startswith("#/"):
+                raise ValueError(
+                    "Invalid predefined model ref "
+                    f"'{ref}'. Keys must be local JSON Pointer refs like "
+                    "'#/definitions/Model'"
+                )
+
+            if not isinstance(model, type) or not issubclass(model, BaseModel):
+                raise ValueError(
+                    f"Invalid predefined model for ref '{ref}'. Values must be subclasses of pydantic.BaseModel"
+                )
+            validated[ref] = model
+        return validated
 
     def create_pydantic_model(
         self,

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -131,6 +131,67 @@ def test_model_with_references():
     assert instance.current_pet.name == "Fluffy"
 
 
+def test_predefined_models_builder_reuses_definition_model():
+    class PetModel(BaseModel):
+        name: str
+        type: str
+
+    builder = PydanticModelBuilder(
+        predefined_models={"#/definitions/Pet": PetModel}
+    )
+    schema = {
+        "type": "object",
+        "properties": {"current_pet": {"$ref": "#/definitions/Pet"}},
+        "definitions": {
+            "Pet": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}, "type": {"type": "string"}},
+            }
+        },
+    }
+
+    model = builder.create_pydantic_model(schema)
+    instance = model(current_pet={"name": "Fluffy", "type": "cat"})
+    assert type(instance.current_pet) is PetModel
+
+
+def test_predefined_models_create_model_reuses_defs_model():
+    from json_schema_to_pydantic import create_model
+
+    class SharedType(BaseModel):
+        value: str
+
+    schema = {
+        "type": "object",
+        "properties": {"shared": {"$ref": "#/$defs/SharedType"}},
+        "$defs": {
+            "SharedType": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+            }
+        },
+    }
+
+    model = create_model(schema, predefined_models={"#/$defs/SharedType": SharedType})
+    instance = model(shared={"value": "ok"})
+    assert type(instance.shared) is SharedType
+
+
+def test_predefined_models_validation_requires_local_ref_keys():
+    with pytest.raises(ValueError, match="Keys must be local JSON Pointer refs"):
+        PydanticModelBuilder(predefined_models={"http://example.com/Pet": BaseModel})
+
+
+def test_predefined_models_validation_requires_basemodel_subclasses():
+    with pytest.raises(ValueError, match="must be subclasses of pydantic.BaseModel"):
+        PydanticModelBuilder(predefined_models={"#/definitions/Pet": str})
+
+
+def test_predefined_models_validation_requires_mapping():
+    with pytest.raises(ValueError, match="predefined_models must be a dict"):
+        PydanticModelBuilder(predefined_models=[])  # type: ignore[arg-type]
+
+
 def test_model_with_combiners():
     """Test model creation with schema combiners."""
     builder = PydanticModelBuilder()

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -182,9 +182,31 @@ def test_predefined_models_validation_requires_local_ref_keys():
         PydanticModelBuilder(predefined_models={"http://example.com/Pet": BaseModel})
 
 
+def test_predefined_models_validation_rejects_empty_pointer_segments():
+    with pytest.raises(ValueError, match="without empty path segments"):
+        PydanticModelBuilder(predefined_models={"#/": BaseModel})
+
+    with pytest.raises(ValueError, match="without empty path segments"):
+        PydanticModelBuilder(predefined_models={"#/definitions//Pet": BaseModel})
+
+
 def test_predefined_models_validation_requires_basemodel_subclasses():
     with pytest.raises(ValueError, match="must be subclasses of pydantic.BaseModel"):
         PydanticModelBuilder(predefined_models={"#/definitions/Pet": str})
+
+
+def test_predefined_models_validation_requires_subclass_of_configured_base_model_type():
+    class CustomBase(BaseModel):
+        base_field: str = "x"
+
+    class DifferentBase(BaseModel):
+        pass
+
+    with pytest.raises(ValueError, match="must be subclasses of the configured base_model_type"):
+        PydanticModelBuilder(
+            base_model_type=CustomBase,
+            predefined_models={"#/definitions/Pet": DifferentBase},
+        )
 
 
 def test_predefined_models_validation_requires_mapping():


### PR DESCRIPTION
## Summary
- add `predefined_models` support to `PydanticModelBuilder` with strict upfront validation
- add `predefined_models` passthrough to top-level `create_model(...)`
- add tests for predefined model reuse (`#/definitions` and `#/$defs`) and validation errors
- document usage and precedence in README and docs/features

## Testing
- `uv run pytest`
- `uv run pytest tests/test_model_builder.py`

Fixes #41