### PR TITLE
feat: support non-model types in predefined refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,18 @@ For more complex scenarios, you can use the `PydanticModelBuilder` directly:
 
 ```python
 from pydantic import BaseModel
+from typing_extensions import TypeAliasType
 from json_schema_to_pydantic import PydanticModelBuilder
 
 class PetModel(BaseModel):
     name: str
     type: str
 
+SomeType = TypeAliasType("SomeType", list[str])
+
 builder = PydanticModelBuilder(
-    predefined_models={"#/definitions/Pet": PetModel}
+    predefined_models={"#/definitions/Pet": PetModel},
+    predefined_refs={"#/definitions/SomeType": SomeType},
 )
 model = builder.create_pydantic_model(schema, root_schema)
 ```
@@ -121,6 +125,8 @@ model = builder.create_pydantic_model(schema, root_schema)
 You can also pass `predefined_models` to `create_model(...)` directly.
 When a `$ref` key matches an entry in `predefined_models`, that class is reused
 instead of generating a new class.
+For non-model aliases (such as `list[str]` or `TypeAliasType`), use
+`predefined_refs`.
 
 ## Error Handling
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -234,6 +234,40 @@ Notes:
 - Values must be subclasses of `pydantic.BaseModel`.
 - Exact ref-key matches take precedence over generated models.
 
+### Reusing Non-Model `$ref` Types
+
+If a `$ref` should resolve to a non-model type alias (for example `list[str]`),
+use `predefined_refs`:
+
+```python
+from typing_extensions import TypeAliasType
+from json_schema_to_pydantic import create_model
+
+SomeType = TypeAliasType("SomeType", list[str])
+
+schema = {
+    "type": "object",
+    "properties": {"some_value": {"$ref": "#/definitions/SomeType"}},
+    "definitions": {
+        "SomeType": {"type": "array", "items": {"type": "string"}}
+    },
+}
+
+Model = create_model(
+    schema,
+    predefined_refs={"#/definitions/SomeType": SomeType},
+)
+instance = Model(some_value=["a", "b"])
+assert instance.some_value == ["a", "b"]
+```
+
+Notes:
+- `predefined_refs` values must be valid Pydantic-compatible type annotations.
+- The same ref key cannot appear in both `predefined_models` and
+  `predefined_refs`.
+- For top-level `$ref` schemas, non-model predefined refs are wrapped into a
+  generated `RootModel`.
+
 ## Limitations
 
 - External references are not supported

--- a/src/json_schema_to_pydantic/__init__.py
+++ b/src/json_schema_to_pydantic/__init__.py
@@ -29,6 +29,7 @@ def create_model(
     allow_undefined_type: bool = False,
     populate_by_name: bool = False,
     predefined_models: Optional[Dict[str, Type[BaseModel]]] = None,
+    predefined_refs: Optional[Dict[str, Any]] = None,
 ) -> Type[T]:
     """
     Create a Pydantic model from a JSON Schema.
@@ -44,6 +45,10 @@ def create_model(
         predefined_models: Optional mapping of local JSON Pointer refs
             (e.g. "#/definitions/MyModel") to existing Pydantic model classes.
             Matching refs are reused instead of generating new model classes.
+        predefined_refs: Optional mapping of local JSON Pointer refs
+            (e.g. "#/definitions/SomeType") to valid type annotations such as
+            list[str], dict[str, int], or TypeAliasType values. Matching refs
+            are reused as field types instead of generating new model classes.
 
     Returns:
         A Pydantic model class
@@ -57,6 +62,7 @@ def create_model(
     builder = PydanticModelBuilder(
         base_model_type=base_model_type,
         predefined_models=predefined_models,
+        predefined_refs=predefined_refs,
     )
     return builder.create_pydantic_model(
         schema,

--- a/src/json_schema_to_pydantic/model_builder.py
+++ b/src/json_schema_to_pydantic/model_builder.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Dict, List, Optional, Set, Type, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel, create_model
+from pydantic import BaseModel, ConfigDict, Field, RootModel, TypeAdapter, create_model
 
 from . import SchemaError
 from .builders import ConstraintBuilder
@@ -89,6 +89,7 @@ class PydanticModelBuilder(IModelBuilder[T]):
         self,
         base_model_type: Type[T] = BaseModel,
         predefined_models: Optional[Dict[str, Type[BaseModel]]] = None,
+        predefined_refs: Optional[Dict[str, Any]] = None,
     ):
         # Instantiate resolvers and builders directly
         self.type_resolver = TypeResolver()
@@ -108,10 +109,36 @@ class PydanticModelBuilder(IModelBuilder[T]):
             predefined_models,
             base_model_type=self.base_model_type,
         )
+        validated_predefined_refs = self._validate_predefined_refs(predefined_refs)
+        overlapping_refs = set(validated_predefined_models).intersection(validated_predefined_refs)
+        if overlapping_refs:
+            overlap_list = ", ".join(sorted(overlapping_refs))
+            raise ValueError(
+                "Duplicate predefined refs found in both predefined_models and predefined_refs: "
+                f"{overlap_list}. Use only one mapping per ref."
+            )
         # Track models being built to handle recursive references
         self._model_cache: Dict[str, Type[BaseModel]] = dict(validated_predefined_models)
+        self._ref_type_cache: Dict[str, Any] = dict(validated_predefined_refs)
         self._building_models: Set[str] = set()
         self._models_to_rebuild: Set[Type[BaseModel]] = set()
+
+    @staticmethod
+    def _validate_ref_key(ref: Any, mapping_name: str) -> str:
+        """Validate local JSON Pointer reference keys used in predefined mappings."""
+        if not isinstance(ref, str) or not ref.startswith("#/"):
+            raise ValueError(
+                f"Invalid {mapping_name} ref '{ref}'. Keys must be local JSON Pointer refs like "
+                "'#/definitions/Model'"
+            )
+
+        path = ref[2:]
+        if not path or any(segment == "" for segment in path.split("/")):
+            raise ValueError(
+                f"Invalid {mapping_name} ref '{ref}'. Keys must be local JSON Pointer refs "
+                "without empty path segments, for example '#/definitions/Model'"
+            )
+        return ref
 
     def _validate_predefined_models(
         self,
@@ -128,19 +155,7 @@ class PydanticModelBuilder(IModelBuilder[T]):
 
         validated: Dict[str, Type[BaseModel]] = {}
         for ref, model in predefined_models.items():
-            if not isinstance(ref, str) or not ref.startswith("#/"):
-                raise ValueError(
-                    "Invalid predefined model ref "
-                    f"'{ref}'. Keys must be local JSON Pointer refs like "
-                    "'#/definitions/Model'"
-                )
-            path = ref[2:]
-            if not path or any(segment == "" for segment in path.split("/")):
-                raise ValueError(
-                    "Invalid predefined model ref "
-                    f"'{ref}'. Keys must be local JSON Pointer refs without empty path segments, "
-                    "for example '#/definitions/Model'"
-                )
+            ref = self._validate_ref_key(ref, "predefined model")
 
             if not isinstance(model, type) or not issubclass(model, BaseModel):
                 raise ValueError(
@@ -153,6 +168,42 @@ class PydanticModelBuilder(IModelBuilder[T]):
                 )
             validated[ref] = model
         return validated
+
+    def _validate_predefined_refs(
+        self,
+        predefined_refs: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Validate and normalize predefined non-model reference mappings."""
+        if predefined_refs is None:
+            return {}
+        if not isinstance(predefined_refs, dict):
+            raise ValueError(
+                "predefined_refs must be a dict mapping local $ref strings to valid type annotations"
+            )
+
+        validated: Dict[str, Any] = {}
+        for ref, annotation in predefined_refs.items():
+            ref = self._validate_ref_key(ref, "predefined ref")
+            try:
+                TypeAdapter(annotation)
+            except Exception as exc:
+                raise ValueError(
+                    f"Invalid predefined ref type for '{ref}'. Value must be a valid "
+                    "Pydantic-compatible type annotation."
+                ) from exc
+            validated[ref] = annotation
+        return validated
+
+    @staticmethod
+    def _get_ref_title(ref: str) -> str:
+        ref_parts = ref.split("/")
+        return ref_parts[-1] if ref_parts else "DynamicModel"
+
+    def _create_predefined_type_root_model(self, ref: str) -> Type[T]:
+        """Wrap a predefined non-model ref type into a RootModel for top-level $ref schemas."""
+        value_type = self._ref_type_cache[ref]
+        title = self._get_ref_title(ref)
+        return type(title, (RootModel[value_type],), {})
 
     def create_pydantic_model(
         self,
@@ -189,6 +240,8 @@ class PydanticModelBuilder(IModelBuilder[T]):
             # Check if we've already built this model
             if original_ref in self._model_cache:
                 return self._model_cache[original_ref]
+            if original_ref in self._ref_type_cache:
+                return self._create_predefined_type_root_model(original_ref)
 
             # Mark this ref as being built
             if original_ref:
@@ -519,6 +572,9 @@ class PydanticModelBuilder(IModelBuilder[T]):
         original_ref = field_schema.get("$ref")
 
         if "$ref" in field_schema:
+            if original_ref in self._ref_type_cache:
+                return self._ref_type_cache[original_ref]
+
             # Check if this reference is already being built (recursive reference)
             if original_ref in self._building_models:
                 # Return cached model if available

--- a/src/json_schema_to_pydantic/model_builder.py
+++ b/src/json_schema_to_pydantic/model_builder.py
@@ -241,7 +241,9 @@ class PydanticModelBuilder(IModelBuilder[T]):
             if original_ref in self._model_cache:
                 return self._model_cache[original_ref]
             if original_ref in self._ref_type_cache:
-                return self._create_predefined_type_root_model(original_ref)
+                predefined_model = self._create_predefined_type_root_model(original_ref)
+                self._model_cache[original_ref] = predefined_model
+                return predefined_model
 
             # Mark this ref as being built
             if original_ref:

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -212,6 +212,19 @@ def test_predefined_refs_top_level_ref_returns_root_model():
     assert model.__name__ == "SomeType"
 
 
+def test_predefined_refs_top_level_ref_model_is_cached():
+    some_type = TypeAliasType("SomeType", list[str])
+    builder = PydanticModelBuilder(predefined_refs={"#/definitions/SomeType": some_type})
+    schema = {"$ref": "#/definitions/SomeType"}
+    root_schema = {
+        "definitions": {"SomeType": {"type": "array", "items": {"type": "string"}}}
+    }
+
+    first = builder.create_pydantic_model(schema, root_schema=root_schema)
+    second = builder.create_pydantic_model(schema, root_schema=root_schema)
+    assert first is second
+
+
 def test_predefined_models_validation_requires_local_ref_keys():
     with pytest.raises(ValueError, match="Keys must be local JSON Pointer refs"):
         PydanticModelBuilder(predefined_models={"http://example.com/Pet": BaseModel})

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1,5 +1,6 @@
 import pytest
 from pydantic import BaseModel, Field, ValidationError
+from typing_extensions import TypeAliasType
 
 # Explicitly import custom TypeError with an alias
 from json_schema_to_pydantic.exceptions import SchemaError, TypeError as JsonSchemaTypeError
@@ -177,6 +178,40 @@ def test_predefined_models_create_model_reuses_defs_model():
     assert type(instance.shared) is SharedType
 
 
+def test_predefined_refs_create_model_reuses_type_alias():
+    from json_schema_to_pydantic import create_model
+
+    some_type = TypeAliasType("SomeType", list[str])
+    schema = {
+        "type": "object",
+        "properties": {"some_value": {"$ref": "#/definitions/SomeType"}},
+        "definitions": {"SomeType": {"type": "array", "items": {"type": "string"}}},
+    }
+
+    model = create_model(schema, predefined_refs={"#/definitions/SomeType": some_type})
+    instance = model(some_value=["a", "b"])
+    assert instance.some_value == ["a", "b"]
+
+
+def test_predefined_refs_top_level_ref_returns_root_model():
+    from json_schema_to_pydantic import create_model
+
+    some_type = TypeAliasType("SomeType", list[str])
+    schema = {"$ref": "#/definitions/SomeType"}
+    root_schema = {
+        "definitions": {"SomeType": {"type": "array", "items": {"type": "string"}}}
+    }
+
+    model = create_model(
+        schema,
+        root_schema=root_schema,
+        predefined_refs={"#/definitions/SomeType": some_type},
+    )
+    instance = model(root=["a", "b"])
+    assert instance.root == ["a", "b"]
+    assert model.__name__ == "SomeType"
+
+
 def test_predefined_models_validation_requires_local_ref_keys():
     with pytest.raises(ValueError, match="Keys must be local JSON Pointer refs"):
         PydanticModelBuilder(predefined_models={"http://example.com/Pet": BaseModel})
@@ -212,6 +247,27 @@ def test_predefined_models_validation_requires_subclass_of_configured_base_model
 def test_predefined_models_validation_requires_mapping():
     with pytest.raises(ValueError, match="predefined_models must be a dict"):
         PydanticModelBuilder(predefined_models=[])  # type: ignore[arg-type]
+
+
+def test_predefined_refs_validation_requires_mapping():
+    with pytest.raises(ValueError, match="predefined_refs must be a dict"):
+        PydanticModelBuilder(predefined_refs=[])  # type: ignore[arg-type]
+
+
+def test_predefined_refs_validation_rejects_invalid_annotation():
+    with pytest.raises(ValueError, match="must be a valid Pydantic-compatible type annotation"):
+        PydanticModelBuilder(predefined_refs={"#/definitions/SomeType": 123})
+
+
+def test_predefined_models_and_refs_conflict_on_same_key():
+    class SomeModel(BaseModel):
+        value: str
+
+    with pytest.raises(ValueError, match="Duplicate predefined refs found"):
+        PydanticModelBuilder(
+            predefined_models={"#/definitions/SomeType": SomeModel},
+            predefined_refs={"#/definitions/SomeType": list[str]},
+        )
 
 
 def test_model_with_combiners():


### PR DESCRIPTION
## Summary
- add `predefined_refs` support to `PydanticModelBuilder` and `create_model(...)` for non-model `$ref` aliases
- validate `predefined_refs` values as Pydantic-compatible type annotations
- add conflict detection when the same ref key appears in both `predefined_models` and `predefined_refs`
- support top-level `$ref` to non-model predefined refs by wrapping into generated `RootModel`
- add tests for type-alias refs, top-level refs, invalid predefined ref values, and overlap conflicts
- update README and feature docs with usage examples

## Testing
- `uv run pytest`